### PR TITLE
Add npm scripts for server and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,16 +132,11 @@ flutter run --dart-define=API_BASE_URL=https://your.api.server/api
 
 When this variable is supplied, the `apiBaseUrl` constant is set to the provided value.
 🌐 Server API Setup (Ubuntu / Windows / Linux)
-1. Clone the server repository
-```bash
-git clone https://github.com/studentsdav/auto_deploy_project.git
-cd auto_deploy_project
-```
-2. Install Node.js dependencies
+1. Install Node.js dependencies in the project root
 ```bash
 npm install
 ```
-3. Set up environment variables
+2. Set up environment variables
 ```bash
 Create a `.env` file in the root directory and add the following:
 
@@ -151,11 +146,11 @@ DB_USER=your_db_user
 DB_PASSWORD=your_db_password
 DB_NAME=your_db_name
 ```
-4. Run the server
+3. Run the server
 ```bash
 npm start
 ```
-5. For development mode (with auto-restart)
+4. For development mode (with auto-restart)
 ```bash
 npm run dev
 ```

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "scripts": {
+    "start": "node global_server_single_use/server.js",
+    "dev": "nodemon global_server_single_use/server.js"
+  },
   "dependencies": {
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",


### PR DESCRIPTION
## Summary
- add `start` and `dev` npm scripts pointing to `global_server_single_use/server.js`
- update README to run the server using these scripts instead of cloning another repo

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685572c631108328a882b3b7a1f2b1f4