### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ git clone https://github.com/studentsdav/point_of_sale_system.git
 ```bash
 cd point_of_sale_system
 ```
-3. Install dependencies
+3. Run the setup script
 ```bash
-flutter pub get
+./scripts/setup.sh
 ```
 4. Run the application
 ```bash

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+# Fetch Flutter dependencies
+echo "Running flutter pub get..."
+flutter pub get
+
+# Install Node.js dependencies
+echo "Running npm install..."
+npm install
+
+# Copy environment file if needed
+if [ -f .env.example ] && [ ! -f .env ]; then
+  echo "Creating .env from .env.example"
+  cp .env.example .env
+fi
+
+echo "Setup complete."


### PR DESCRIPTION
## Summary
- add a `scripts/setup.sh` script to install Flutter and Node dependencies
- copy `.env.example` to `.env` when needed
- document the setup script in the installation guide

## Testing
- `npm test` *(fails: Missing script)*
- `flutter --version` *(fails: command not found)*
- `./scripts/setup.sh` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_685572ca766883289c9598c1ffaade14