### PR TITLE
Add floating action buttons for order actions

### DIFF
--- a/lib/screens/orders/kotform.dart
+++ b/lib/screens/orders/kotform.dart
@@ -592,19 +592,6 @@ class _KOTFormScreenState extends State<KOTFormScreen> {
                             ),
                           ),
                           const SizedBox(height: 20),
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                            children: [
-                              ElevatedButton(
-                                onPressed: _saveOrder,
-                                child: const Text('Save Order'),
-                              ),
-                              ElevatedButton(
-                                onPressed: _printOrder,
-                                child: const Text('Print Order'),
-                              ),
-                            ],
-                          ),
                         ],
                       ),
                     ),
@@ -778,6 +765,24 @@ class _KOTFormScreenState extends State<KOTFormScreen> {
                       ),
                     ),
                   )
+                ],
+              ),
+              floatingActionButtonLocation:
+                  FloatingActionButtonLocation.centerFloat,
+              floatingActionButton: Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  FloatingActionButton.extended(
+                    onPressed: _saveOrder,
+                    icon: const Icon(Icons.save),
+                    label: const Text('Save'),
+                  ),
+                  const SizedBox(width: 10),
+                  FloatingActionButton.extended(
+                    onPressed: _printOrder,
+                    icon: const Icon(Icons.print),
+                    label: const Text('Print'),
+                  ),
                 ],
               ),
             );


### PR DESCRIPTION
## Summary
- remove the Row of elevated buttons on the order form
- add `FloatingActionButton.extended` widgets for Save and Print
- position FABs using `floatingActionButton` and `floatingActionButtonLocation`

## Testing
- `dart format lib/screens/orders/kotform.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a4761df348328b34062c17b674c75